### PR TITLE
Fix: Update "Add calendar" link with new calendar ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dust",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.4",

--- a/src/components/Home/index.js
+++ b/src/components/Home/index.js
@@ -82,7 +82,7 @@ const Home = () => {
         <Hero />
         <div className="text-center">
           <p className="text-2xl md:text-5xl m-8">
-            Join us for our next meetup:
+            Join us for our next skate:
           </p>
           <div className="text-center text-4xl font-special font-bold m-16">
             Loading...
@@ -137,7 +137,7 @@ const Home = () => {
           </button>
           <a
             className="text-sky-500 underline font-medium"
-            href="https://calendar.google.com/calendar/u/5?cid=ZGVudmVydXJiYW5za2F0ZXRyb29wQGdtYWlsLmNvbQ"
+            href="https://calendar.google.com/calendar/u/0?cid=OTkzZGRhYTE5NWFhMTlkZjI4NWIxNGEzZDViNTNhMzUxNjJlMjIyYTFiZGViMjBkODY2Y2UzMTBjOTc3NzBiNUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t"
             target="_blank"
             rel="noreferrer"
           >


### PR DESCRIPTION
Partially addresses: https://github.com/Abdeboskey/dust/issues/18

## Summary
- Update calendar link to use new calendar ID
- Change "meetup" to "skate" in home page text

![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExNDVhemJxZ3RxdDY2YTJ6dXpmM2dzdHp5amh2NHJpNHZ2ZHFwYXgwNyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/WtMgPMG6Z2NP6uD9wd/giphy.gif)